### PR TITLE
infiniband bug #8854

### DIFF
--- a/virtualbox/steps/data/puppet/modules/env/files/base/infiniband/openibd
+++ b/virtualbox/steps/data/puppet/modules/env/files/base/infiniband/openibd
@@ -702,6 +702,7 @@ bring_up()
                 Debian)
                     . ${NETWORK_CONF_DIR}/ifcfg-${i}
                     /sbin/ip address add ${IPADDR}/${NETMASK} dev ${i} > /dev/null 2>&1
+                    /sbin/ip link set ${i} up > /dev/null 2>&1
                 ;;
             *)
                     /sbin/ifup ${i} 2> /dev/null


### PR DESCRIPTION
Corrige le bug #8854, le script d'init monte l'ip sur l'interface mais ne "up" pas l'interface, cette PR corrige cela