### PR TITLE
increase memory and vcpus of virtualbox vm

### DIFF
--- a/virtualbox/steps/bootstrap/start_virtualbox.yaml
+++ b/virtualbox/steps/bootstrap/start_virtualbox.yaml
@@ -15,6 +15,7 @@
   - exec_local: VBoxManage modifyvm $${virtualbox_vmid} --ostype $${virtualbox_os_type}
   - exec_local: VBoxManage modifyvm $${virtualbox_vmid} --boot1 disk
   - exec_local: VBoxManage modifyvm $${virtualbox_vmid} --memory $${virtualbox_memory_size}
+  - exec_local: VBoxManage modifyvm $${virtualbox_vmid} --cpus $${virtualbox_cpus}
   - exec_local: VBoxManage modifyvm $${virtualbox_vmid} --acpi on
   - exec_local: VBoxManage modifyvm $${virtualbox_vmid} --nictype1 82540EM
   - exec_local: VBoxManage modifyvm $${virtualbox_vmid} --nictype2 82540EM

--- a/virtualbox/steps/global/virtualbox_options.yaml
+++ b/virtualbox/steps/global/virtualbox_options.yaml
@@ -4,7 +4,8 @@ image_format: vmdk
 appliance_formats: vmdk tar.gz
 
 ## VirtualBox options
-virtualbox_memory_size: 768
+virtualbox_memory_size: 8192
+virtualbox_cpus: 16
 virtualbox_os_type: Linux_64
 virtualbox_vmid: $${kameleon_recipe_name}_$${kameleon_short_uuid}
 


### PR DESCRIPTION
increase memory to 8GB (768MB previously) and number of VCPU to 16 (only one previously)