### PR TITLE
Tuto kameleon bugfix cloudinit w cache

### DIFF
--- a/virtualbox/steps/export/cloud_init_qcow2.yaml
+++ b/virtualbox/steps/export/cloud_init_qcow2.yaml
@@ -3,7 +3,8 @@
 - install_cloud_init:
   - exec_local: |
       echo "Install cloud_init in qcow2"
-      virt-customize -a $${output}.qcow2 --install cloud-init
+      # First unset any proxy variable (set to http://127.0.0.1:8000 if kameleon's cache is enabled) so that virt-customise works ok
+      (for e in $(env | grep -i _proxy); do unset ${e%%=*}; done; virt-customize -a $${output}.qcow2 --install cloud-init)
       echo "Configure datasource and timeout for cloud_init"
       virt-customize -a $${output}.qcow2 --run-command 'echo "datasource_list: [  NoCloud, Ec2, None ]" > /etc/cloud/cloud.cfg.d/91-set-datasources.cfg'
       virt-customize -a $${output}.qcow2 --run-command 'echo "datasource:\n  Ec2:\n    timeout: 3\n    max_wait: 5" > /etc/cloud/cloud.cfg.d/92-set-ec2-timeout.cfg'

--- a/virtualbox/steps/export/export_g5k.yaml
+++ b/virtualbox/steps/export/export_g5k.yaml
@@ -19,7 +19,7 @@
       if [[ "x$${variant}" != "xxen" ]]; then
       cat << EOF > $${output}.dsc
       $${dashes}
-      name: $${os_release}-x64-$${variant}
+      name: $${kameleon_recipe_name}
       version: $${image_version}
       description: $(echo $${os_family}|cut -c1|tr [a-z] [A-Z])$(echo $${os_family}|cut -c2-) $(echo $${os_release}|cut -c1|tr [a-z] [A-Z])$(echo $${os_release}|cut -c2-) ($${variant})
       author: support-staff@lists.grid5000.fr
@@ -45,7 +45,7 @@
       else
       cat << EOF > $${output}.dsc
       $${dashes}
-      name: $${os_release}-x64-$${variant}
+      name: $${kameleon_recipe_name}
       version: $${image_version}
       description: $(echo $${os_family}|cut -c1|tr [a-z] [A-Z])$(echo $${os_family}|cut -c2-) $(echo $${os_release}|cut -c1|tr [a-z] [A-Z])$(echo $${os_release}|cut -c2-) ($${variant})
       author: support-staff@lists.grid5000.fr
@@ -71,6 +71,4 @@
       EOF
       fi
 - generate_md5:
-  - exec_local: |
-      md5sum $${os_release}-x64-$${variant}.* > $${os_release}-x64-$${variant}.md5
-      
+  - exec_local: md5sum $${kameleon_recipe_name}.* > $${kameleon_recipe_name}.md5


### PR DESCRIPTION
Bugfix:
1. the cloudinit step did not work if building with `kameleon build --enable-cache`
2. export_g5k did not work with recipe names other than jessie-x64-* 