### PR TITLE
[sshd_config] see bug #9223

### DIFF
--- a/virtualbox/steps/data/puppet/modules/env/files/min/ssh/sshd_config
+++ b/virtualbox/steps/data/puppet/modules/env/files/min/ssh/sshd_config
@@ -1,78 +1,123 @@
-# Package generated configuration file
-# See the sshd(8) manpage for details
+#	$OpenBSD: sshd_config,v 1.100 2016/08/15 12:32:04 naddy Exp $
 
-# What ports, IPs and protocols we listen for
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
 Port 22
-# Use these options to restrict which interfaces/protocols sshd will bind to
-#ListenAddress ::
+#AddressFamily any
 #ListenAddress 0.0.0.0
-Protocol 2
-# HostKeys for protocol version 2
-HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_dsa_key
-#Privilege Separation is turned on for security
-UsePrivilegeSeparation no
+#ListenAddress ::
 
-# Lifetime and size of ephemeral version 1 server key
-KeyRegenerationInterval 3600
-ServerKeyBits 768
+HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
 
 # Logging
 SyslogFacility AUTH
 LogLevel INFO
 
 # Authentication:
-LoginGraceTime 120
-PermitRootLogin yes
+
+LoginGraceTime 2m
+PermitRootLogin prohibit-password
 StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
 
-RSAAuthentication yes
 PubkeyAuthentication yes
-#AuthorizedKeysFile	%h/.ssh/authorized_keys
 
+# Expect .ssh/authorized_keys2 to be disregarded by default in future.
+#AuthorizedKeysFile	.ssh/authorized_keys .ssh/authorized_keys2
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
 # Don't read the user's ~/.rhosts and ~/.shosts files
 IgnoreRhosts yes
-# For this to work you will also need host keys in /etc/ssh_known_hosts
-RhostsRSAAuthentication no
-# similar for protocol version 2
-HostbasedAuthentication no
-# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
-#IgnoreUserKnownHosts yes
 
-# To enable empty passwords, change to yes (NOT RECOMMENDED)
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication no
 PermitEmptyPasswords no
 
 # Change to yes to enable challenge-response passwords (beware issues with
 # some PAM modules and threads)
 ChallengeResponseAuthentication no
 
-# Change to no to disable tunnelled clear text passwords
-#PasswordAuthentication yes
-
 # Kerberos options
 #KerberosAuthentication no
-#KerberosGetAFSToken no
 #KerberosOrLocalPasswd yes
 #KerberosTicketCleanup yes
+#KerberosGetAFSToken no
 
 # GSSAPI options
 #GSSAPIAuthentication no
 #GSSAPICleanupCredentials yes
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
 
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
 X11Forwarding yes
 X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
 PrintMotd no
 PrintLastLog yes
 TCPKeepAlive yes
 #UseLogin no
+UsePrivilegeSeparation no
+PermitUserEnvironment yes
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
 
-#MaxStartups 10:30:60
-#Banner /etc/issue.net
+# no default banner path
+#Banner none
 
 # Allow client to pass locale environment variables
-PermitUserEnvironment yes
 AcceptEnv LANG LC_*
 
-Subsystem sftp /usr/lib/openssh/sftp-server
+# override default of no subsystems
+Subsystem	sftp	/usr/lib/openssh/sftp-server
 
-UsePAM yes
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server

--- a/virtualbox/steps/data/puppet/modules/env/files/std/oar/sshd_config
+++ b/virtualbox/steps/data/puppet/modules/env/files/std/oar/sshd_config
@@ -1,62 +1,120 @@
-# OAR sshd configuration file
+#	$OpenBSD: sshd_config,v 1.100 2016/08/15 12:32:04 naddy Exp $
 
-# What ports, IPs and protocols we listen for
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
 Port 6667
-# Use these options to restrict which interfaces/protocols sshd will bind to
-#ListenAddress ::
+#AddressFamily any
 #ListenAddress 0.0.0.0
-Protocol 2
-# HostKeys for protocol version 2
+#ListenAddress ::
+
 HostKey /etc/oar/oar_ssh_host_rsa_key
-HostKey /etc/oar/oar_ssh_host_dsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
 
-# [Grid5000] This 3 lines are useful for ulimits
-UsePrivilegeSeparation no
-UsePam yes
-ChallengeResponseAuthentication yes
-
-# Lifetime and size of ephemeral version 1 server key
-KeyRegenerationInterval 3600
-ServerKeyBits 768
+# Ciphers and keying
+#RekeyLimit default none
 
 # Logging
 SyslogFacility AUTH
 LogLevel INFO
 
 # Authentication:
-LoginGraceTime 600
+
+LoginGraceTime 10m
 PermitRootLogin no
 StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
 
-RSAAuthentication yes
 PubkeyAuthentication yes
-#AuthorizedKeysFile	%h/.ssh/authorized_keys
 
+# Expect .ssh/authorized_keys2 to be disregarded by default in future.
+#AuthorizedKeysFile	.ssh/authorized_keys .ssh/authorized_keys2
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
 # Don't read the user's ~/.rhosts and ~/.shosts files
 IgnoreRhosts yes
-# For this to work you will also need host keys in /etc/ssh_known_hosts
-RhostsRSAAuthentication no
-# similar for protocol version 2
-HostbasedAuthentication no
 
-# To enable empty passwords, change to yes (NOT RECOMMENDED)
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication no
 PermitEmptyPasswords no
 
-# Change to yes to enable tunnelled clear text passwords
-PasswordAuthentication no
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
 
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
 
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
 X11Forwarding yes
 X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
 PrintMotd no
 PrintLastLog yes
-KeepAlive yes
 TCPKeepAlive yes
+#UseLogin no
+UsePrivilegeSeparation no
+PermitUserEnvironment yes
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+MaxStartups 500
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+# override default of no subsystems
+Subsystem	sftp	/usr/lib/openssh/sftp-server
 
 AcceptEnv OAR_CPUSET OAR_JOB_USER
-PermitUserEnvironment yes
-UseLogin no
 AllowUsers oar
 XAuthLocation /usr/bin/xauth
-
-MaxStartups 500


### PR DESCRIPTION
- config rebased on the default debian config
- removal of dsa HostKey because they are now deprecated