### PR TITLE
[infiniband] change NETMASK=255.255.240.0 by 255.255.255.0 in ifcfg-i…

### DIFF
--- a/virtualbox/steps/data/puppet/modules/env/files/base/infiniband/ifcfg-ib0
+++ b/virtualbox/steps/data/puppet/modules/env/files/base/infiniband/ifcfg-ib0
@@ -1,6 +1,6 @@
 DEVICE=ib0
 BOOTPROTO=static
 IPADDR=$(host -t A $(hostname -s)-ib0 | cut -d' ' -f4)
-NETMASK=255.255.240.0
+NETMASK=255.255.255.0
 ONBOOT=yes
 


### PR DESCRIPTION
 Bug9663 - adressage pour les réseaux IB/OPA
changement du masque pour les interfaces ib0 de /20 en /24.
test snapshot sur jenkins ok (dans le bug)

